### PR TITLE
resolved type constraints issue in variables.tf and argument definition issue in eks-vpc.tf

### DIFF
--- a/eks-vpc.tf
+++ b/eks-vpc.tf
@@ -102,7 +102,7 @@ resource "aws_route_table" "eks-private" {
   vpc_id = "${aws_vpc.eks.id}"
 
   tags {
-        Name = "route table for private subnets",
+        Name = "route table for private subnets"
     }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,6 @@
 variable "cluster-name" {
   description = "Enter eks cluster name - example like eks-demo, eks-dev etc"
-  type    = "string"
+  type    = string
 }
 
 variable "eks-worker-ami" {
@@ -23,13 +23,13 @@ variable "ssh_key_pair" {
 }
 
 variable "public_subnets" {
-    type    = "list"
+    type    = list
     description = "you can replace these values as per your choice of subnet range"
     default = ["10.15.0.0/22", "10.15.4.0/22", "10.15.8.0/22"]
 }
 
 variable "private_subnets" {
-    type    = "list"
+    type    = list
     description = "you can replace these values as per your choice of subnet range"
     default = ["10.15.12.0/22", "10.15.16.0/22", "10.15.20.0/22"]
 }


### PR DESCRIPTION
Closes #12 
1) Terraform 0.11 and earlier required type constraints to be given in quotes, as that is now deprecated. Removed the quotes around type constraints in the variables.tf.
2) Argument definitions must be separated by newlines, not commas. An argument definition must end with a newline. So removed the comma in the eks-vpc.tf